### PR TITLE
Do not validate the payment details for this service

### DIFF
--- a/amazon_payments/views.py
+++ b/amazon_payments/views.py
@@ -648,7 +648,7 @@ class AmazonUpdateTaxesAndShippingView(BaseAmazonPaymentDetailsView):
             data['msg'] = _("You need to add some items to your basket to check out.")
         else:
             try:
-                amazon_order_details = self.get_amazon_order_details(request)
+                amazon_order_details = self.get_amazon_order_details(request, validate_payment_details=False)
             except AmazonPaymentsAPIError, e:
                 logger.debug(unicode(e))
                 if e.args[0] == "InvalidAddressConsentToken":

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='django-oscar-amazon-payments',
-    version="0.2.2",
+    version="0.2.3",
     url='https://github.com/simonkagwe/django-oscar-amazon-payments',
     author="Simon Kagwi",
     author_email="simonkagwe@yahoo.com",


### PR DESCRIPTION
will prevent visual bugs where messages will show up to the user when this service is called, saying that payment details are not selected
